### PR TITLE
Make Persistence Plugin synchronous and therefore independent of signal effects

### DIFF
--- a/packages/signalstory/src/lib/store-plugin-persistence/plugin-persistence.ts
+++ b/packages/signalstory/src/lib/store-plugin-persistence/plugin-persistence.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { assertInInjectionContext, effect } from '@angular/core';
 import { Store } from '../store';
 import { StorePlugin, StoreState } from '../store-plugin';
 import {
@@ -118,17 +117,9 @@ export function useStorePersistence(
       if (persistedState) {
         store.set(persistedState, 'Load state from storage');
       }
-
-      if (!store.config.injector) {
-        assertInInjectionContext(useStorePersistence);
-      }
-
-      effect(
-        () => {
-          saveToStoreStorage(store, store.state());
-        },
-        { injector: store.config.injector ?? undefined }
-      );
+    },
+    postprocessCommand(store) {
+      saveToStoreStorage(store, store.state());
     },
   };
 


### PR DESCRIPTION
Make Persistence Plugin synchronous and therefore independent of signal effects. Reason therefore is, that effects are fired in a change detection cycle and if there is no cycle, no effect is triggered. This behaviours has been changed for newer version of  angular, see: https://github.com/angular/angular/pull/51049