### PR TITLE
Introduce configuration object to effect creation

### DIFF
--- a/packages/signalstory/src/__tests__/store.spec.ts
+++ b/packages/signalstory/src/__tests__/store.spec.ts
@@ -202,10 +202,12 @@ describe('runEffect', () => {
     });
   });
 
-  it('should runEffect', () => {
+  it('should runEffect without injection context', () => {
     // arrange
     const func = jest.fn();
-    const effect = createEffect('effect', func);
+    const effect = createEffect('effect', func, {
+      withInjectionContext: false,
+    });
     const argument = 42;
 
     // act
@@ -216,13 +218,49 @@ describe('runEffect', () => {
     expect(func).toHaveBeenCalledWith(store, argument);
   });
 
-  it('should runEffect in injection context', () => {
+  it('should runEffect without injection context using deprecated method', () => {
+    // arrange
+    const func = jest.fn();
+    const effect = createEffect('effect', func, false);
+    const argument = 42;
+
+    // act
+    store.runEffect(effect, argument);
+
+    // assert
+    expect(func).toHaveBeenCalledTimes(1);
+    expect(func).toHaveBeenCalledWith(store, argument);
+  });
+
+  it('should runEffect in injection context by default', () => {
     // arrange
     const argumentFunc = jest.fn();
     const effect = createEffect('effect', (_, arg) => {
       const store2 = inject(ImmutableTestStore);
       arg(store2);
     });
+
+    // act
+    store.runEffect(effect, argumentFunc);
+
+    // assert
+    expect(argumentFunc).toHaveBeenCalledTimes(1);
+    expect(argumentFunc).toHaveBeenCalledWith(supportingStore);
+  });
+
+  it('should runEffect in injection context configured by config object', () => {
+    // arrange
+    const argumentFunc = jest.fn();
+    const effect = createEffect(
+      'effect',
+      (_, arg) => {
+        const store2 = inject(ImmutableTestStore);
+        arg(store2);
+      },
+      {
+        withInjectionContext: true,
+      }
+    );
 
     // act
     store.runEffect(effect, argumentFunc);

--- a/packages/signalstory/src/lib/store-effect.ts
+++ b/packages/signalstory/src/lib/store-effect.ts
@@ -18,7 +18,7 @@ export interface StoreEffect<
 > {
   name: string; // The name of the effect.
   func: (store: TStore, ...args: TArgs) => TResult; // The function representing the effect.
-  config: Readonly<Required<StoreEffectConfig>>; // Indicates whether the effect requires an injection context.
+  config: Readonly<Required<StoreEffectConfig>>; // effect configuration
 }
 
 /**

--- a/packages/signalstory/src/lib/store-effect.ts
+++ b/packages/signalstory/src/lib/store-effect.ts
@@ -2,6 +2,13 @@
 import { Store } from './store';
 
 /**
+ * Configuration for a store effect.
+ */
+export interface StoreEffectConfig {
+  withInjectionContext?: boolean; // Indicates whether the effect requires an injection context.
+}
+
+/**
  * Represents an effect that can be executed on a store.
  */
 export interface StoreEffect<
@@ -11,14 +18,14 @@ export interface StoreEffect<
 > {
   name: string; // The name of the effect.
   func: (store: TStore, ...args: TArgs) => TResult; // The function representing the effect.
-  withInjectionContext: boolean; // Indicates whether the effect requires an injection context.
+  config: Readonly<Required<StoreEffectConfig>>; // Indicates whether the effect requires an injection context.
 }
 
 /**
- * Creates a new store effect with the provided name, function, and injection context option.
+ * Creates a new store effect with the provided name, function, and configuration.
  * @param name The name of the effect.
  * @param func The function representing the effect.
- * @param withInjectionContext Specifies whether the effect requires an injection context. Default is true.
+ * @param config Configuration options for the effect.
  * @returns A store effect object.
  */
 export function createEffect<
@@ -28,11 +35,45 @@ export function createEffect<
 >(
   name: string,
   func: (store: TStore, ...args: TArgs) => TResult,
-  withInjectionContext = true
+  config?: StoreEffectConfig
+): StoreEffect<TStore, TArgs, TResult>;
+
+/**
+ * Creates a new store effect with the provided name, function, and injection context option.
+ * @param name The name of the effect.
+ * @param func The function representing the effect.
+ * @param withInjectionContext Specifies whether the effect requires an injection context. Default is true.
+ * @returns A store effect object.
+ * @deprecated Use the overload with a configuration object instead.
+ */
+export function createEffect<
+  TStore extends Store<any>,
+  TArgs extends any[],
+  TResult,
+>(
+  name: string,
+  func: (store: TStore, ...args: TArgs) => TResult,
+  withInjectionContext?: boolean
+): StoreEffect<TStore, TArgs, TResult>;
+
+/**
+ * Implementation of the createEffect function.
+ */
+export function createEffect<
+  TStore extends Store<any>,
+  TArgs extends any[],
+  TResult,
+>(
+  name: string,
+  func: (store: TStore, ...args: TArgs) => TResult,
+  arg?: boolean | StoreEffectConfig
 ): StoreEffect<TStore, TArgs, TResult> {
   return {
     name,
     func,
-    withInjectionContext,
+    config: {
+      withInjectionContext:
+        !arg || arg === true || (arg.withInjectionContext ?? false),
+    },
   };
 }


### PR DESCRIPTION
`createEffect` now takes a configuration object as parameter. Therefore the `withInjectionContext` parameter is deprecated as it is included inside the configuration object parameter