### PR TITLE
Introduce StoreStatus Plugin

### DIFF
--- a/packages/signalstory/src/__tests__/store-plugin-status.spec.ts
+++ b/packages/signalstory/src/__tests__/store-plugin-status.spec.ts
@@ -10,7 +10,7 @@ import {
   markAsHavingNoRunningEffects,
   markAsUnmodified,
   runningEffects,
-  useStatus,
+  useStoreStatus,
 } from '../lib/store-plugin-status/plugin-status';
 
 describe('StoreStatusPlugin', () => {
@@ -18,7 +18,7 @@ describe('StoreStatusPlugin', () => {
     // act
     const store = new Store<{ val: number }>({
       initialState: { val: 5 },
-      plugins: [useStatus()],
+      plugins: [useStoreStatus()],
     });
 
     // assert
@@ -36,7 +36,7 @@ describe('StoreStatusPlugin', () => {
     beforeEach(() => {
       store = new Store<{ value: number }>({
         initialState: { value: initialValue },
-        plugins: [useStatus()],
+        plugins: [useStoreStatus()],
       });
       runningEffects.set([]);
     });
@@ -158,7 +158,7 @@ describe('isLoading', () => {
     runningEffects.set([]);
     store = new Store<{ value: number }>({
       initialState: { value: 10 },
-      plugins: [useStatus()],
+      plugins: [useStoreStatus()],
     });
   });
 
@@ -209,7 +209,7 @@ describe('isAnyEffectRunning', () => {
     runningEffects.set([]);
     store = new Store<{ value: number }>({
       initialState: { value: 10 },
-      plugins: [useStatus()],
+      plugins: [useStoreStatus()],
     });
   });
 
@@ -260,7 +260,7 @@ describe('isEffectRunning', () => {
     runningEffects.set([]);
     store = new Store<{ value: number }>({
       initialState: { value: 10 },
-      plugins: [useStatus()],
+      plugins: [useStoreStatus()],
     });
   });
 
@@ -314,7 +314,7 @@ describe('isModified', () => {
   beforeEach(() => {
     store = new Store<{ value: number }>({
       initialState: { value: 10 },
-      plugins: [useStatus()],
+      plugins: [useStoreStatus()],
     });
   });
 
@@ -381,7 +381,7 @@ describe('markAsUnmodified', () => {
   beforeEach(() => {
     store = new Store<{ value: number }>({
       initialState: { value: 10 },
-      plugins: [useStatus()],
+      plugins: [useStoreStatus()],
     });
   });
 
@@ -405,7 +405,7 @@ describe('markAsHavingNoRunningEffects', () => {
   beforeEach(() => {
     store = new Store<{ value: number }>({
       initialState: { value: 10 },
-      plugins: [useStatus()],
+      plugins: [useStoreStatus()],
     });
     runningEffects.set([]);
   });
@@ -425,7 +425,7 @@ describe('markAsHavingNoRunningEffects', () => {
     // arrange
     const otherStore = new Store<{ value: number }>({
       initialState: { value: 20 },
-      plugins: [useStatus()],
+      plugins: [useStoreStatus()],
     });
     runningEffects.set([
       [new WeakRef(store), effect],

--- a/packages/signalstory/src/__tests__/store-plugin-status.spec.ts
+++ b/packages/signalstory/src/__tests__/store-plugin-status.spec.ts
@@ -1,0 +1,353 @@
+/* eslint-disable tree-shaking/no-side-effects-in-initialization */
+import { delay, lastValueFrom, of, tap } from 'rxjs';
+import { Store } from '../lib/store';
+import { createEffect } from '../lib/store-effect';
+import {
+  isAnyEffectRunning,
+  isEffectRunning,
+  isLoading,
+  isModified,
+  runningEffects,
+  useStatus,
+} from '../lib/store-plugin-status/plugin-status';
+
+describe('StoreStatusPlugin', () => {
+  it('should be created using plugin factory method', () => {
+    // act
+    const store = new Store<{ val: number }>({
+      initialState: { val: 5 },
+      plugins: [useStatus()],
+    });
+
+    // assert
+    expect(store['initPostprocessor']).toHaveLength(1);
+    expect(store['commandPreprocessor']).toBeUndefined();
+    expect(store['commandPostprocessor']).toHaveLength(1);
+    expect(store['effectPreprocessor']).toHaveLength(1);
+    expect(store['effectPostprocessor']).toHaveLength(1);
+  });
+
+  describe('Running effect', () => {
+    let store: Store<{ value: number }>;
+    const initialValue = 10;
+
+    beforeEach(() => {
+      store = new Store<{ value: number }>({
+        initialState: { value: initialValue },
+        plugins: [useStatus()],
+      });
+    });
+
+    it('should register observable efffect while it runs', async () => {
+      // arrange
+      const newValue = 22;
+      const effect = createEffect(
+        'dummyEffect',
+        (store: Store<{ value: number }>) =>
+          of(newValue).pipe(
+            tap(val =>
+              store.mutate(x => {
+                x.value = val;
+              })
+            ),
+            tap(() => {
+              expect(runningEffects()).toHaveLength(1);
+              expect(runningEffects()[0][1]).toBe(effect);
+            })
+          )
+      );
+
+      // act & assert
+      expect(runningEffects()).toHaveLength(0);
+
+      await lastValueFrom(store.runEffect(effect));
+
+      expect(runningEffects()).toHaveLength(0);
+      expect(store.state().value).toBe(newValue);
+    });
+
+    it('should register throwing observable efffect while it runs', async () => {
+      // arrange
+      const effect = createEffect('dummyEffect', () =>
+        of().pipe(
+          tap(() => {
+            expect(runningEffects()).toHaveLength(1);
+            expect(runningEffects()[0][1]).toBe(effect);
+            throw new Error('Error');
+          })
+        )
+      );
+
+      // act & assert
+      expect(runningEffects()).toHaveLength(0);
+
+      try {
+        await lastValueFrom(store.runEffect(effect));
+      } catch (_) {
+        /* empty */
+      }
+
+      expect(runningEffects()).toHaveLength(0);
+    });
+
+    it('should handle multiple effects running concurrently', async () => {
+      // arrange
+      const effect1 = createEffect(
+        'effect1',
+        (store: Store<{ value: number }>) =>
+          of(30).pipe(
+            delay(100),
+            tap(val =>
+              store.mutate(x => {
+                x.value = val;
+              })
+            )
+          )
+      );
+      const effect2 = createEffect(
+        'effect2',
+        (store: Store<{ value: number }>) =>
+          of(40).pipe(
+            tap(val =>
+              store.mutate(x => {
+                x.value = val;
+              })
+            )
+          )
+      );
+
+      // act
+      await Promise.all([
+        lastValueFrom(store.runEffect(effect1)),
+        lastValueFrom(store.runEffect(effect2)),
+      ]);
+
+      // assert
+      expect(runningEffects()).toHaveLength(0);
+    });
+  });
+});
+
+describe('isLoading', () => {
+  let store: Store<{ value: number }>;
+
+  beforeEach(() => {
+    runningEffects.set([]);
+    store = new Store<{ value: number }>({
+      initialState: { value: 10 },
+      plugins: [useStatus()],
+    });
+  });
+
+  it('should be false if no effect is running', () => {
+    // act
+    const isLoadingStatus = isLoading(store)();
+    const isAnyLoadingStatus = isLoading()();
+
+    // assert
+    expect(isLoadingStatus).toBe(false);
+    expect(isAnyLoadingStatus).toBe(false);
+  });
+
+  it('should be false for a running effect that has not been created with setLoadingStatus enabled', () => {
+    // arrange
+    const effect = createEffect('effect', () => {});
+    runningEffects.set([[new WeakRef(store), effect]]);
+
+    // act
+    const isLoadingStatus = isLoading(store)();
+    const isAnyLoadingStatus = isLoading()();
+
+    // assert
+    expect(isLoadingStatus).toBe(false);
+    expect(isAnyLoadingStatus).toBe(false);
+  });
+
+  it('should be true for a running effect that has been created with setLoadingStatus enabled', () => {
+    // arrange
+    const effect = createEffect('effect', () => {}, { setLoadingStatus: true });
+    runningEffects.set([[new WeakRef(store), effect]]);
+
+    // act
+    const isLoadingStatus = isLoading(store)();
+    const isAnyLoadingStatus = isLoading()();
+
+    // assert
+    expect(isLoadingStatus).toBe(true);
+    expect(isAnyLoadingStatus).toBe(true);
+  });
+});
+
+describe('isAnyEffectRunning', () => {
+  let store: Store<{ value: number }>;
+  const effect = createEffect('effect', () => {});
+
+  beforeEach(() => {
+    runningEffects.set([]);
+    store = new Store<{ value: number }>({
+      initialState: { value: 10 },
+      plugins: [useStatus()],
+    });
+  });
+
+  it('should be false if no effect is running', () => {
+    // act
+    const isRunningForStore = isAnyEffectRunning(store)();
+    const isRunningForAnyStore = isAnyEffectRunning()();
+
+    // assert
+    expect(isRunningForStore).toBe(false);
+    expect(isRunningForAnyStore).toBe(false);
+  });
+
+  it('should be false for a running effect that is registered for another store', () => {
+    // arrange
+    runningEffects.set([
+      [new WeakRef(new Store<number>({ initialState: 0 })), effect],
+    ]);
+
+    // act
+    const isRunningForStore = isAnyEffectRunning(store)();
+    const isRunningForAnyStore = isAnyEffectRunning()();
+
+    // assert
+    expect(isRunningForStore).toBe(false);
+    expect(isRunningForAnyStore).toBe(true);
+  });
+
+  it('should be true for a running effect and the corresponding store', () => {
+    // arrange
+    runningEffects.set([[new WeakRef(store), effect]]);
+
+    // act
+    const isRunningForStore = isAnyEffectRunning(store)();
+    const isRunningForAnyStore = isAnyEffectRunning()();
+
+    // assert
+    expect(isRunningForStore).toBe(true);
+    expect(isRunningForAnyStore).toBe(true);
+  });
+});
+
+describe('isEffectRunning', () => {
+  let store: Store<{ value: number }>;
+  const effect = createEffect('effect', () => {});
+
+  beforeEach(() => {
+    runningEffects.set([]);
+    store = new Store<{ value: number }>({
+      initialState: { value: 10 },
+      plugins: [useStatus()],
+    });
+  });
+
+  it('should be false if effect is not running', () => {
+    // arrange
+    runningEffects.set([
+      [new WeakRef(store), createEffect('Other eeffect', () => {})],
+    ]);
+
+    // act
+    const isRunningForStore = isEffectRunning(effect, store)();
+    const isRunningForAnyStore = isEffectRunning(effect)();
+
+    // assert
+    expect(isRunningForStore).toBe(false);
+    expect(isRunningForAnyStore).toBe(false);
+  });
+
+  it('should be false for a running effect that is registered for another store', () => {
+    // arrange
+    runningEffects.set([
+      [new WeakRef(new Store<number>({ initialState: 0 })), effect],
+    ]);
+
+    // act
+    const isRunningForStore = isEffectRunning(effect, store)();
+    const isRunningForAnyStore = isEffectRunning(effect)();
+
+    // assert
+    expect(isRunningForStore).toBe(false);
+    expect(isRunningForAnyStore).toBe(true);
+  });
+
+  it('should be true for a running effect and the corresponding store', () => {
+    // arrange
+    runningEffects.set([[new WeakRef(store), effect]]);
+
+    // act
+    const isRunningForStore = isEffectRunning(effect, store)();
+    const isRunningForAnyStore = isEffectRunning(effect)();
+
+    // assert
+    expect(isRunningForStore).toBe(true);
+    expect(isRunningForAnyStore).toBe(true);
+  });
+});
+
+describe('isModified', () => {
+  let store: Store<{ value: number }>;
+
+  beforeEach(() => {
+    store = new Store<{ value: number }>({
+      initialState: { value: 10 },
+      plugins: [useStatus()],
+    });
+  });
+
+  it('should be unmodified initially', () => {
+    // assert
+    expect(isModified(store)()).toBe(false);
+  });
+
+  it('should mark the store as modified after a command is processed', () => {
+    // act
+    store.set({ value: 10 });
+
+    // assert
+    expect(isModified(store)()).toBe(true);
+  });
+
+  it('should mark the store as modified after an effect is processed', async () => {
+    // arrange
+    const effect = createEffect(
+      'dummyEffect',
+      (store: Store<{ value: number }>) =>
+        of(30).pipe(
+          tap(val =>
+            store.mutate(x => {
+              x.value = val;
+            })
+          )
+        )
+    );
+
+    // act
+    await lastValueFrom(store.runEffect(effect));
+
+    // assert
+    expect(isModified(store)()).toBe(true);
+  });
+
+  it('should mark the store as unmodified after an effect with setUnmodifiedStatus is processed', async () => {
+    // arrange
+    const effect = createEffect(
+      'dummyEffect',
+      (store: Store<{ value: number }>) =>
+        of(30).pipe(
+          tap(val =>
+            store.mutate(x => {
+              x.value = val;
+            })
+          )
+        ),
+      { setUnmodifiedStatus: true }
+    );
+
+    // act
+    await lastValueFrom(store.runEffect(effect));
+
+    // assert
+    expect(isModified(store)()).toBe(false);
+  });
+});

--- a/packages/signalstory/src/lib/store-effect.ts
+++ b/packages/signalstory/src/lib/store-effect.ts
@@ -5,9 +5,24 @@ import { Store } from './store';
  * Configuration for a store effect.
  */
 export interface StoreEffectConfig {
-  withInjectionContext?: boolean; // Indicates whether the effect requires an injection context. Defaults to true.
-  setLoadingStatus?: boolean; // Indicates whether the effect sets loading status. Defaults to false.
-  setUnmodifiedStatus?: boolean; // Indicates whether the effect sets unmodified status. Defaults to false.
+  /**
+   * Indicates whether the effect requires an injection context. Defaults to true.
+   */
+  withInjectionContext?: boolean;
+
+  /**
+   * Indicates whether the effect sets loading status.
+   * Only applicable if the `StoreStatus` plugin is used.
+   * Defaults to false.
+   */
+  setLoadingStatus?: boolean;
+
+  /**
+   * Indicates whether the effect sets unmodified status.
+   * Only applicable if the `StoreStatus` plugin is used.
+   * Defaults to false.
+   */
+  setUnmodifiedStatus?: boolean;
 }
 
 /**

--- a/packages/signalstory/src/lib/store-effect.ts
+++ b/packages/signalstory/src/lib/store-effect.ts
@@ -5,7 +5,9 @@ import { Store } from './store';
  * Configuration for a store effect.
  */
 export interface StoreEffectConfig {
-  withInjectionContext?: boolean; // Indicates whether the effect requires an injection context.
+  withInjectionContext?: boolean; // Indicates whether the effect requires an injection context. Defaults to true.
+  setLoadingStatus?: boolean; // Indicates whether the effect sets loading status. Defaults to false.
+  setUnmodifiedStatus?: boolean; // Indicates whether the effect sets unmodified status. Defaults to false.
 }
 
 /**
@@ -73,7 +75,10 @@ export function createEffect<
     func,
     config: {
       withInjectionContext:
-        !arg || arg === true || (arg.withInjectionContext ?? false),
+        !arg || arg === true || (arg.withInjectionContext ?? true),
+      setLoadingStatus: (arg as StoreEffectConfig)?.setLoadingStatus ?? false,
+      setUnmodifiedStatus:
+        (arg as StoreEffectConfig)?.setUnmodifiedStatus ?? false,
     },
   };
 }

--- a/packages/signalstory/src/lib/store-plugin-status/plugin-status.ts
+++ b/packages/signalstory/src/lib/store-plugin-status/plugin-status.ts
@@ -43,6 +43,7 @@ export function isModified(store: Store<any>): Signal<boolean> {
  * flag on the relevant effects to automatically manage the modification status.
  *
  * @param store - The store to manually mark as unmodified.
+ * @returns void
  */
 export function markAsUnmodified(store: Store<any>): void {
   isStoreModifiedMap.get(store)?.set(false);
@@ -74,6 +75,23 @@ export function isLoading(...stores: Store<any>[]): Signal<boolean> {
       })
     );
   }
+}
+
+/**
+ * Manually marks the provided store as not having any running effects.
+ *
+ * @note This method is intended for exceptional cases, specifically when you observe
+ * that an effect is not removed from the running state by signalstory automatically.
+ * If you encounter such a situation, use this method as a temporary workaround and
+ * be sure to file an issue on GitHub for further investigation and resolution.
+ *
+ * @param store - The store to manually mark as not having running effects.
+ * @returns void
+ */
+export function markAsHavingNoRunningEffects(store: Store<any>): void {
+  runningEffects.update(state =>
+    state.filter(runningEffect => runningEffect[0].deref() !== store)
+  );
 }
 
 /**

--- a/packages/signalstory/src/lib/store-plugin-status/plugin-status.ts
+++ b/packages/signalstory/src/lib/store-plugin-status/plugin-status.ts
@@ -1,0 +1,150 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// eslint-disable-next-line tree-shaking/no-side-effects-in-initialization
+import { Signal, WritableSignal, computed, signal } from '@angular/core';
+import { Store } from '../store';
+import { StoreEffect } from '../store-effect';
+import { StorePlugin } from '../store-plugin';
+import { withSideEffect } from '../utility/sideeffect';
+
+const isStoreModifiedMap = new WeakMap<
+  Store<unknown>,
+  WritableSignal<boolean>
+>();
+
+export const runningEffects: WritableSignal<
+  [WeakRef<Store<any>>, StoreEffect<any, any, any>][]
+> = signal([]);
+
+/**
+ * Returns a Signal indicating whether the provided store has been modified.
+ *
+ * @note A store is initially considered unmodified. Any command (`set`, `update`, `mutate`) applied to the store
+ * will mark it as modified. Additionally, an effect created with the `setUnmodifiedStatus` flag can reset the store's
+ * modification status to unmodified.
+ *
+ * @param store - The store to check for modification status.
+ * @returns Signal<boolean> - A signal indicating whether the store has been modified.
+ */
+export function isModified(store: Store<any>): Signal<boolean> {
+  const modifiedStatus = isStoreModifiedMap.get(store);
+  if (!modifiedStatus) {
+    throw new Error(
+      `StatusPlugin has not been activated for store ${store.name}`
+    );
+  }
+
+  return computed(() => modifiedStatus());
+}
+
+/**
+ * Manually marks the provided store as unmodified.
+ *
+ * @note This method is intended for exceptional cases. In most scenarios, consider using the `setUnmodifiedStatus`
+ * flag on the relevant effects to automatically manage the modification status.
+ *
+ * @param store - The store to manually mark as unmodified.
+ */
+export function markAsUnmodified(store: Store<any>): void {
+  isStoreModifiedMap.get(store)?.set(false);
+}
+
+/**
+ * Returns a Signal indicating whether any of the provided stores is in a loading state.
+ * If no stores are provided, the returned signal indicates if any store is in a loading state.
+ *
+ * @note An effect created with `setLoadingStatus` will mark the associated store as loading while the effect is running.
+ *
+ * @param stores - Stores to check for loading status. If no stores are provided, the signal checks all stores.
+ * @returns Signal<boolean> - A signal indicating whether any store is loading.
+ */
+export function isLoading(...stores: Store<any>[]): Signal<boolean> {
+  if (!stores || stores.length === 0) {
+    return computed(() =>
+      runningEffects().some(effect => effect[1].config.setLoadingStatus)
+    );
+  } else {
+    return computed(() =>
+      runningEffects().some(runningEffect => {
+        const affectedStore = runningEffect[0].deref();
+        return (
+          affectedStore &&
+          runningEffect[1].config.setLoadingStatus &&
+          stores.some(store => store === affectedStore)
+        );
+      })
+    );
+  }
+}
+
+/**
+ * Returns a Signal indicating whether any effect is currently running for any of the provided stores.
+ * If no Store is provided the returned signal indicates if any store has an effect running
+ * @param stores - Stores to check for running effects.
+ * @returns Signal<boolean> - A signal indicating whether any effect is running for any store.
+ */
+export function isAnyEffectRunning(...stores: Store<any>[]): Signal<boolean> {
+  if (!stores || stores.length === 0) {
+    return computed(() => runningEffects().length > 0);
+  } else {
+    return computed(() =>
+      runningEffects().some(runningEffect => {
+        const affectedStore = runningEffect[0].deref();
+        return affectedStore && stores.some(store => store === affectedStore);
+      })
+    );
+  }
+}
+
+/**
+ * Returns a Signal indicating whether the specified effect is currently running for any of the provided stores.
+ * If no Store is provided the returned signal indicates if any store has the given effect running
+ * @param effect - The effect to check for.
+ * @param stores - Stores to check for the specified effect.
+ * @returns Signal<boolean> - A signal indicating whether the specified effect is running for any store.
+ */
+export function isEffectRunning(
+  effect: StoreEffect<any, any, any>,
+  ...stores: Store<any>[]
+): Signal<boolean> {
+  if (!stores || stores.length === 0) {
+    return computed(() => runningEffects().some(x => x[1] === effect));
+  } else {
+    return computed(() =>
+      runningEffects()
+        .filter(runningEffect => runningEffect[1] === effect)
+        .some(runningEffect => {
+          const affectedStore = runningEffect[0].deref();
+          return affectedStore && stores.some(store => store === affectedStore);
+        })
+    );
+  }
+}
+
+/**
+ * Enables StorePlugin that tracks the loading and modification status of a store.
+ * @returns A StorePlugin instance for loading and modification status tracking.
+ */
+export function useStatus(): StorePlugin {
+  return {
+    init(store) {
+      isStoreModifiedMap.set(store, signal(false));
+    },
+    postprocessCommand(store) {
+      isStoreModifiedMap.get(store)?.set(true);
+    },
+    preprocessEffect(store, effect) {
+      runningEffects.update(effects => [
+        ...effects,
+        [new WeakRef(store), effect],
+      ]);
+    },
+    postprocessEffect(store, effect, result) {
+      return withSideEffect(result, () => {
+        runningEffects.update(effects => effects.filter(x => x[1] !== effect));
+        if (effect.config.setUnmodifiedStatus) {
+          isStoreModifiedMap.get(store)?.set(false);
+        }
+      });
+    },
+  };
+}

--- a/packages/signalstory/src/lib/store-plugin-status/plugin-status.ts
+++ b/packages/signalstory/src/lib/store-plugin-status/plugin-status.ts
@@ -142,7 +142,7 @@ export function isEffectRunning(
  * Enables StorePlugin that tracks the loading and modification status of a store.
  * @returns A StorePlugin instance for loading and modification status tracking.
  */
-export function useStatus(): StorePlugin {
+export function useStoreStatus(): StorePlugin {
   return {
     init(store) {
       isStoreModifiedMap.set(store, signal(false));

--- a/packages/signalstory/src/public-api.ts
+++ b/packages/signalstory/src/public-api.ts
@@ -28,6 +28,7 @@ export {
   isEffectRunning,
   isLoading,
   isModified,
+  markAsHavingNoRunningEffects,
   markAsUnmodified,
   useStatus,
 } from './lib/store-plugin-status/plugin-status';

--- a/packages/signalstory/src/public-api.ts
+++ b/packages/signalstory/src/public-api.ts
@@ -30,6 +30,6 @@ export {
   isModified,
   markAsHavingNoRunningEffects,
   markAsUnmodified,
-  useStatus,
+  useStoreStatus,
 } from './lib/store-plugin-status/plugin-status';
 export { StoreQuery, createQuery } from './lib/store-query';

--- a/packages/signalstory/src/public-api.ts
+++ b/packages/signalstory/src/public-api.ts
@@ -23,4 +23,12 @@ export {
   clearStoreStorage,
   useStorePersistence,
 } from './lib/store-plugin-persistence/plugin-persistence';
+export {
+  isAnyEffectRunning,
+  isEffectRunning,
+  isLoading,
+  isModified,
+  markAsUnmodified,
+  useStatus,
+} from './lib/store-plugin-status/plugin-status';
 export { StoreQuery, createQuery } from './lib/store-query';


### PR DESCRIPTION
This pull request introduces a new `StorePlugin` named `StoreStatus` which can be enabled by `useStoreStatus`. It  enhances the functionality of the existing Store class by tracking loading and modification status. This plugin provides signals and utility functions to easily monitor and manage the state of stores.