### PR TITLE
Sideeffects in effect postprocessors should be consolidated in a single finalize block

### DIFF
--- a/packages/signalstory/src/lib/store-plugin-logger/plugin-logger.ts
+++ b/packages/signalstory/src/lib/store-plugin-logger/plugin-logger.ts
@@ -1,5 +1,4 @@
 import { StorePlugin } from '../store-plugin';
-import { withSideEffect } from '../utility/sideeffect';
 
 /**
  * Represents a logger function that can be used for logging messages.
@@ -41,13 +40,11 @@ export function useLogger(
       `[${store.name}->Effect STARTED] ${effect.name ?? 'Unspecified'}`,
       store.state()
     );
-  plugin.postprocessEffect = (store, effect, result) =>
-    withSideEffect(result, () => {
-      plugin.log(
-        `[${store.name}->Effect FINNISHED] ${effect.name ?? 'Unspecified'}`,
-        store.state()
-      );
-    });
+  plugin.postprocessEffect = (store, effect) =>
+    plugin.log(
+      `[${store.name}->Effect FINNISHED] ${effect.name ?? 'Unspecified'}`,
+      store.state()
+    );
 
   return plugin;
 }

--- a/packages/signalstory/src/lib/store-plugin-status/plugin-status.ts
+++ b/packages/signalstory/src/lib/store-plugin-status/plugin-status.ts
@@ -4,7 +4,6 @@ import { Signal, WritableSignal, computed, signal } from '@angular/core';
 import { Store } from '../store';
 import { StoreEffect } from '../store-effect';
 import { StorePlugin } from '../store-plugin';
-import { withSideEffect } from '../utility/sideeffect';
 
 const isStoreModifiedMap = new WeakMap<
   Store<unknown>,
@@ -156,13 +155,11 @@ export function useStoreStatus(): StorePlugin {
         [new WeakRef(store), effect],
       ]);
     },
-    postprocessEffect(store, effect, result) {
-      return withSideEffect(result, () => {
-        runningEffects.update(effects => effects.filter(x => x[1] !== effect));
-        if (effect.config.setUnmodifiedStatus) {
-          isStoreModifiedMap.get(store)?.set(false);
-        }
-      });
+    postprocessEffect(store, effect) {
+      runningEffects.update(effects => effects.filter(x => x[1] !== effect));
+      if (effect.config.setUnmodifiedStatus) {
+        isStoreModifiedMap.get(store)?.set(false);
+      }
     },
   };
 }


### PR DESCRIPTION
At the moment, multiple observable/promise based effect postprocessors will pipe their own finalize/finally block. This is not optimal, since there is no guarantee about ordering.

From now on, all effect postprocessor will be accumulated inside a single finalize/finally block.