### PR TITLE
Support tuple types in Immutable<T> type definition

### DIFF
--- a/packages/signalstory/src/lib/store-immutability/immutable-utility.ts
+++ b/packages/signalstory/src/lib/store-immutability/immutable-utility.ts
@@ -19,10 +19,11 @@ export function naiveDeepClone<TState>(state: TState): TState {
  * @param {T} value - The value object to be cloned.
  * @returns {T} A deep clone of the provided value object.
  */
-export const deepClone = <TState>(state: TState) =>
-  window && 'structuredClone' in window
+export function deepClone<TState>(state: TState): TState {
+  return window && 'structuredClone' in window
     ? structuredClone(state)
     : naiveDeepClone(state);
+}
 
 /**
  * Creates a shallow clone of a given value object

--- a/packages/signalstory/src/lib/store-mediator.ts
+++ b/packages/signalstory/src/lib/store-mediator.ts
@@ -25,7 +25,7 @@ export function createRegistry(): MediatorRegistry {
 /**
  * Root mediator registry instance.
  */
-export const rootRegistry: MediatorRegistry = createRegistry();
+export const rootRegistry: MediatorRegistry = /*@__PURE__*/ createRegistry();
 
 /**
  * Register an event handler for a specific event.


### PR DESCRIPTION
Now tuple types can also be the target of the Immutable type. Further, some more pure annotations were added in otrder to help terser tree shake globals