### PR TITLE
Introducing improved Feature Detection for SSR

### DIFF
--- a/docs/docs/plugins/persistence.md
+++ b/docs/docs/plugins/persistence.md
@@ -49,6 +49,17 @@ useStorePersistence({
 });
 ```
 
+## Feature detection (SSR)
+
+In cases where the storage providers are not available, for example for SSR, the plugin does not get registered and will not throw an error.
+Hence, you can reuse your Store plugin declerations without changing anything. However, note that Angular raises an error if there's an attempt to reference unsupported global variables during SSR. To work around this, instead of using the actual window variable, simply specify the string constant `LOCAL_STORAGE` or `SESSION_STORAGE`.
+
+```typescript
+useStorePersistence({
+  persistenceStorage: 'SESSION_STORAGE',
+});
+```
+
 ## Loading the Persisted State
 
 When your application starts up or the store is initialized, signalstory automatically loads the persisted state from the storage, if available.

--- a/packages/signalstory/.eslintrc.json
+++ b/packages/signalstory/.eslintrc.json
@@ -24,8 +24,7 @@
             "prefix": "lib",
             "style": "kebab-case"
           }
-        ],
-        "tree-shaking/no-side-effects-in-initialization": 2
+        ]
       }
     },
     {

--- a/packages/signalstory/src/lib/store-plugin-devtools/plugin-devtools.ts
+++ b/packages/signalstory/src/lib/store-plugin-devtools/plugin-devtools.ts
@@ -1,5 +1,6 @@
 import { Store } from '../store';
 import { StorePlugin } from '../store-plugin';
+import { isDevtoolsAvailable } from '../utility/feature-detection';
 
 /**
  * Represents a Redux action.
@@ -72,14 +73,8 @@ let devtools: Devtools | undefined;
  * @param options DevTools options.
  */
 function initDevtools(options: DevtoolsOptions = {}): void {
-  if (window && '__REDUX_DEVTOOLS_EXTENSION__' in window) {
-    devtools = window.__REDUX_DEVTOOLS_EXTENSION__.connect(options);
-    devtools.subscribe(handleDevtoolsMessage);
-  } else {
-    console.warn(
-      'ATTENTION: Attempted to initialize redux devtools, but no browser extension was found!'
-    );
-  }
+  devtools = window.__REDUX_DEVTOOLS_EXTENSION__.connect(options);
+  devtools.subscribe(handleDevtoolsMessage);
 }
 
 /**
@@ -171,6 +166,10 @@ export function removeFromDevtools<TStore extends Store<unknown>>(
  * @returns Devtools Storeplugin
  */
 export function useDevtools(): StorePlugin {
+  if (!isDevtoolsAvailable()) {
+    return {};
+  }
+
   return {
     init(store) {
       registerForDevtools(store);

--- a/packages/signalstory/src/lib/store-plugin-performance-counter/plugin-performance-counter.ts
+++ b/packages/signalstory/src/lib/store-plugin-performance-counter/plugin-performance-counter.ts
@@ -1,7 +1,7 @@
-/* eslint-disable tree-shaking/no-side-effects-in-initialization */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { StorePlugin } from '../store-plugin';
 import { registry } from '../store-plugin-devtools/plugin-devtools';
+import { isDevtoolsAvailable } from '../utility/feature-detection';
 import { PerformanceCounter } from './performance-counter';
 
 /**
@@ -121,7 +121,7 @@ export function usePerformanceCounter(): StorePlugin {
   return {
     precedence: 11, // should come early in initialization
     init() {
-      if (!registry.has(counterStore.name)) {
+      if (isDevtoolsAvailable() && !registry.has(counterStore.name)) {
         registry.set(counterStore.name, new WeakRef(counterStore) as any);
       }
     },

--- a/packages/signalstory/src/lib/utility/feature-detection.ts
+++ b/packages/signalstory/src/lib/utility/feature-detection.ts
@@ -1,0 +1,45 @@
+import { memoize } from './memoize';
+
+/**
+ * Creates a memoized function for feature detection.
+ *
+ * @param detectionFn - Function that performs the feature detection.
+ * @returns Memoized function for feature detection.
+ */
+function makeFeatureDetector(detectionFn: () => boolean) {
+  return memoize(() => {
+    try {
+      return detectionFn();
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
+ * Feature detection for IndexedDB availability.
+ */
+export const isIndexedDbAvailable = /*@__PURE__*/ makeFeatureDetector(
+  () => !!indexedDB
+);
+
+/**
+ * Feature detection for Local Storage availability.
+ */
+export const isLocalStorageAvailable = /*@__PURE__*/ makeFeatureDetector(
+  () => !!localStorage
+);
+
+/**
+ * Feature detection for Session Storage availability.
+ */
+export const isSessionStorageAvailable = /*@__PURE__*/ makeFeatureDetector(
+  () => !!sessionStorage
+);
+
+/**
+ * Feature detection for Redux DevTools availability.
+ */
+export const isDevtoolsAvailable = /*@__PURE__*/ makeFeatureDetector(
+  () => window && '__REDUX_DEVTOOLS_EXTENSION__' in window
+);

--- a/packages/signalstory/src/lib/utility/memoize.ts
+++ b/packages/signalstory/src/lib/utility/memoize.ts
@@ -1,0 +1,15 @@
+/**
+ * Memoizes a function by caching its result and returning the cached result on subsequent calls.
+ * @param fn - The function to be memoized.
+ * @returns A memoized version of the input function.
+ */
+export function memoize<T>(fn: () => T): () => T {
+  let cachedResult: T | undefined;
+
+  return () => {
+    if (cachedResult === undefined) {
+      cachedResult = fn();
+    }
+    return cachedResult;
+  };
+}


### PR DESCRIPTION
This PR enables the client to reuse store plugin declerations without changing anything for SSR. In cases where the storage providers are not available the plugin does not get registered and will not throw an error.
