### PR TITLE
feat(core): Introduce State Snapshot feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Here's a snapshot of some notable highlights:
 ✅ &nbsp;Immutability on demand  
 ✅ &nbsp;Rich plugin ecosystem  
 ✅ &nbsp;Native IndexedDB support  
-✅ &nbsp;Granular Undo/Redo  
+✅ &nbsp;Granular Undo/Redo
+✅ &nbsp;Global State Snaphots and Rollbacks
 ✅ &nbsp;Devtools support  
 ✅ &nbsp;Effect and Store status tracking  
 ✅ &nbsp;Realtime store performance statistics  

--- a/docs/docs/plugins/_category_.json
+++ b/docs/docs/plugins/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Plugins",
-  "position": 9,
+  "position": 10,
   "link": {
     "type": "generated-index",
     "description": "Plugins provide specialized capabilities to enhance a single store's functionality. Multiple built-in plugins enable you to track and navigate state changes, streamline debugging, persist store data in a storage and more. But you are also able to create your own unique plugins to customize any store's behaviour."

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # Testing

--- a/packages/signalstory/src/__tests__/store-snapshot.spec.ts
+++ b/packages/signalstory/src/__tests__/store-snapshot.spec.ts
@@ -1,0 +1,175 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable tree-shaking/no-side-effects-in-initialization */
+import { Store } from '../lib/store';
+import { clearRegistry, forEachStoreInScope } from '../lib/store-registry';
+import { StateSnapshot, createSnapshot } from '../lib/store-snapshot';
+
+class DummyStore1 extends Store<number> {
+  constructor(initialState = 0) {
+    super({ initialState });
+  }
+}
+
+class DummyStore2 extends Store<number> {
+  constructor(initialState = 0) {
+    super({ initialState });
+  }
+}
+
+function getStoresFromSnapshot(snapshot: StateSnapshot) {
+  const stores: Store<unknown>[] = [];
+  const storesCapturedBySnapshot = (snapshot as any)[
+    'storesWithState'
+  ] as WeakMap<Store<unknown>, unknown>;
+
+  forEachStoreInScope(store => {
+    if (storesCapturedBySnapshot.has(store)) {
+      stores.push(store);
+    }
+  });
+
+  return stores;
+}
+
+describe('createSnapshot', () => {
+  beforeEach(() => {
+    clearRegistry();
+  });
+
+  it('should create a correctly timestamped snapshot without any registered stores if no stores in scope', () => {
+    // arrange & act
+    const snapshot = createSnapshot();
+
+    // assert
+    expect(snapshot.timestamp).toBeGreaterThan(0);
+    expect(getStoresFromSnapshot(snapshot)).toHaveLength(0);
+  });
+
+  it('Should create a snapshot with the correctly captured stores', () => {
+    // arrange
+    const storeDummy1 = new DummyStore1();
+    const storeDummy2 = new DummyStore2();
+    const store1 = new Store<string>({ initialState: '' });
+    const store2 = new Store<string>({ initialState: '' });
+
+    // act
+    const snapshotNone = createSnapshot();
+    const snapshotDummy1 = createSnapshot(DummyStore1);
+    const snapshotStore1 = createSnapshot(store1);
+    const snapshotDummy1And2 = createSnapshot(DummyStore1, DummyStore2);
+    const snapshotDummy1AndStore1 = createSnapshot(DummyStore1, store1);
+    const snapshotAll = createSnapshot(
+      storeDummy1,
+      storeDummy2,
+      store1,
+      store2
+    );
+
+    // assert
+    expect(getStoresFromSnapshot(snapshotNone)).toStrictEqual([
+      storeDummy1,
+      storeDummy2,
+      store1,
+      store2,
+    ]);
+    expect(getStoresFromSnapshot(snapshotDummy1)).toStrictEqual([storeDummy1]);
+    expect(getStoresFromSnapshot(snapshotStore1)).toStrictEqual([store1]);
+    expect(getStoresFromSnapshot(snapshotDummy1And2)).toStrictEqual([
+      storeDummy1,
+      storeDummy2,
+    ]);
+    expect(getStoresFromSnapshot(snapshotDummy1AndStore1)).toStrictEqual([
+      storeDummy1,
+      store1,
+    ]);
+    expect(getStoresFromSnapshot(snapshotAll)).toStrictEqual([
+      storeDummy1,
+      storeDummy2,
+      store1,
+      store2,
+    ]);
+  });
+});
+
+describe('snapshot.restore', () => {
+  beforeEach(() => {
+    clearRegistry();
+  });
+
+  it('Should not throw if no stores in scope', () => {
+    // arrange
+    const snapshot = createSnapshot();
+
+    // act
+    const act = () => snapshot.restore();
+
+    // assert
+    expect(act).not.toThrow();
+  });
+
+  it('should restore only the captured store and not all stores in scope', () => {
+    // arrange
+    const initialState = 10;
+    const store1 = new Store<number>({ initialState });
+    const store2 = new DummyStore1(initialState);
+
+    const snapshot = createSnapshot(store1);
+
+    const newState = 45;
+    store1.set(newState);
+    store2.set(newState);
+
+    // act
+    snapshot.restore();
+
+    // assert
+    expect(store1.state()).toBe(initialState);
+    expect(store2.state()).toBe(newState);
+  });
+
+  it('should restore only the captured stores and not all stores in scope', () => {
+    // arrange
+    const initialState = 10;
+    const store1 = new Store<number>({ initialState });
+    const store2 = new Store<number>({ initialState });
+    const store3 = new DummyStore1(initialState);
+    const store4 = new DummyStore2(initialState);
+
+    const snapshot = createSnapshot(store1, DummyStore1);
+
+    const newState = 45;
+    store1.set(newState);
+    store2.set(newState);
+    store3.set(newState);
+    store4.set(newState);
+
+    // act
+    snapshot.restore();
+
+    // assert
+    expect(store1.state()).toBe(initialState);
+    expect(store2.state()).toBe(newState);
+    expect(store3.state()).toBe(initialState);
+    expect(store4.state()).toBe(newState);
+  });
+
+  it('should restore all stores in scope if no store is specified at snapshot creation', () => {
+    // arrange
+    const initialState = 10;
+    const store1 = new Store<number>({ initialState });
+    const store2 = new DummyStore1(initialState);
+
+    const snapshot = createSnapshot();
+
+    const newState = 45;
+    store1.set(newState);
+    store2.set(newState);
+
+    // act
+    snapshot.restore();
+
+    // assert
+    expect(store1.state()).toBe(initialState);
+    expect(store2.state()).toBe(initialState);
+  });
+});

--- a/packages/signalstory/src/lib/store-registry.ts
+++ b/packages/signalstory/src/lib/store-registry.ts
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Store } from './store';
+
+/**
+ * Store registry of stores currently in scope
+ */
+const storeRegistry = new Set<WeakRef<Store<unknown>>>();
+
+/**
+ * Iterates over each store in the registry and executes the specified callback function.
+ *
+ * @param callbackFn - The callback function to be executed for each store in the registry.
+ */
+export function forEachStoreInScope(
+  callbackFn: (store: Store<unknown>) => void
+) {
+  storeRegistry.forEach(registration => {
+    const store = registration.deref();
+    if (store) {
+      callbackFn(store);
+    } else {
+      storeRegistry.delete(registration);
+    }
+  });
+}
+
+/**
+ * Adds a store to the registry.
+ *
+ * @param store - The store to be added to the registry.
+ */
+export function addToRegistry(store: Store<any>) {
+  storeRegistry.add(new WeakRef(store));
+}
+
+/**
+ * Cleare Store registry.
+ * Only used for tests
+ *
+ */
+export function clearRegistry() {
+  storeRegistry.clear();
+}

--- a/packages/signalstory/src/lib/store-snapshot.ts
+++ b/packages/signalstory/src/lib/store-snapshot.ts
@@ -1,0 +1,75 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ProviderToken } from '@angular/core';
+import { Store } from './store';
+import { forEachStoreInScope } from './store-registry';
+
+/**
+ * Represents the snapshot restore command.
+ */
+export const RestoreCommand = '_SNAPSHOT_RESTORE_';
+
+/**
+ * Represents a snapshot of the application state.
+ */
+export interface StateSnapshot {
+  /**
+   * The timestamp when the snapshot was created.
+   */
+  readonly timestamp: number;
+
+  /**
+   * Restores the application state to the captured snapshot.
+   */
+  restore: () => void;
+}
+
+/**
+ * Base implementation of the StateSnapshot interface.
+ */
+class StateSnapshotBase implements StateSnapshot {
+  readonly timestamp = performance.now();
+
+  constructor(
+    private readonly storesWithState: WeakMap<Store<unknown>, unknown>
+  ) {}
+
+  restore(): void {
+    forEachStoreInScope(store => {
+      if (this.storesWithState.has(store)) {
+        const snapshotValue = this.storesWithState.get(store);
+        if (snapshotValue !== store.state()) {
+          store.set(snapshotValue, RestoreCommand);
+        }
+      }
+    });
+  }
+}
+
+/**
+ * Creates a state snapshot either for specified stores or all stores in scope.
+ *
+ * If no stores are provided, the snapshot will include all stores currently in scope.
+ * Stores can be specified either as instances of Store or as ProviderTokens representing
+ * Store classes.
+ *
+ * @param stores - The stores for which to create a snapshot. Can be either instances
+ * of Store or ProviderTokens representing Store classes.
+ * @returns A StateSnapshot instance representing the application state snapshot.
+ */
+export function createSnapshot(
+  ...stores: (Store<any> | ProviderToken<Store<any>>)[]
+): StateSnapshot {
+  const storesWithState = new WeakMap<Store<unknown>, unknown>();
+
+  if (stores && stores.length > 0) {
+    forEachStoreInScope(store => {
+      if (stores.some(x => x === store || store.constructor === x)) {
+        storesWithState.set(store, store.state());
+      }
+    });
+  } else {
+    forEachStoreInScope(store => storesWithState.set(store, store.state()));
+  }
+
+  return new StateSnapshotBase(storesWithState);
+}

--- a/packages/signalstory/src/lib/store.ts
+++ b/packages/signalstory/src/lib/store.ts
@@ -24,6 +24,7 @@ import {
 } from './store-plugin';
 import { useLogger } from './store-plugin-logger/plugin-logger';
 import { StoreQuery } from './store-query';
+import { addToRegistry } from './store-registry';
 import { getInjectorOrNull } from './utility/injector-helper';
 import { withSideEffect } from './utility/sideeffect';
 
@@ -68,6 +69,8 @@ export class Store<TState> {
     ) {
       this.config.plugins.push(useLogger());
     }
+
+    addToRegistry(this);
 
     this.config.plugins
       .sort((a, b) => (b.precedence ?? 0) - (a.precedence ?? 0))

--- a/packages/signalstory/src/public-api.ts
+++ b/packages/signalstory/src/public-api.ts
@@ -40,3 +40,4 @@ export {
   useStoreStatus,
 } from './lib/store-plugin-status/plugin-status';
 export { StoreQuery, createQuery } from './lib/store-query';
+export { createSnapshot } from './lib/store-snapshot';


### PR DESCRIPTION
The State Snapshot feature has been added to the library, providing users with the ability to capture and restore the state of multiple stores within an application. This is particularly useful for scenarios requiring transactional guarantees, enabling users to rollback across various stores.

This pull request also introduces a store registry, which can be used by new features in the future