### PR TITLE
style(plugin-status): :lipstick: declares the runningEffects signal as pure

### DIFF
--- a/packages/signalstory/src/lib/store-plugin-status/plugin-status.ts
+++ b/packages/signalstory/src/lib/store-plugin-status/plugin-status.ts
@@ -12,7 +12,7 @@ const isStoreModifiedMap = new WeakMap<
 
 export const runningEffects: WritableSignal<
   [WeakRef<Store<any>>, StoreEffect<any, any, any>, number][]
-> = signal([]);
+> = /*@__PURE__*/ signal([]);
 
 /**
  * Returns a Signal indicating whether the provided store has been modified.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation content changes
[x] Other... Please describe:
```

## What is the current behavior?

Terser does not identify the `signal` creation function as a `pure`.  Hence, the `runningEffects` signal constant is not tree-shakable.

## What is the new behavior?

Declares the initialization of `runningEffects` as `pure`, which makes it tree-shakeable.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```