### PR TITLE
chore: :hammer: remove eslint-plugin-tree-shaking

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,6 @@
 {
   "root": true,
   "ignorePatterns": ["packages/**/*"],
-  "plugins": [
-    "tree-shaking"
-  ],
   "overrides": [
     {
       "files": ["*.ts"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,6 @@
         "eslint": "^8.54.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.1",
-        "eslint-plugin-tree-shaking": "^1.11.0",
         "husky": "^8.0.3",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
@@ -10506,15 +10505,6 @@
         "eslint-config-prettier": {
           "optional": true
         }
-      }
-    },
-    "node_modules/eslint-plugin-tree-shaking": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-tree-shaking/-/eslint-plugin-tree-shaking-1.11.0.tgz",
-      "integrity": "sha512-t2QO9dCZDmERlEiClC80t3oR+jKnP47iWCPGYtp6kOJNaGcFIUp1+dUZSSbVScW8EDMXHY7PnxuDRBJutPYIWQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "eslint": "^8.54.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.1",
-    "eslint-plugin-tree-shaking": "^1.11.0",
     "husky": "^8.0.3",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",

--- a/packages/signalstory/src/__tests__/helper.ts
+++ b/packages/signalstory/src/__tests__/helper.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @angular-eslint/component-class-suffix */
-/* eslint-disable tree-shaking/no-side-effects-in-initialization */
 import { Component, InjectionToken, inject } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { ImmutableStore } from '../lib/store-immutability/immutable-store';

--- a/packages/signalstory/src/__tests__/immutable-store.spec.ts
+++ b/packages/signalstory/src/__tests__/immutable-store.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-empty-function */
-/* eslint-disable tree-shaking/no-side-effects-in-initialization */
 import { computed } from '@angular/core';
 import { ImmutableStore } from '../lib/store-immutability/immutable-store';
 import { rootRegistry } from '../lib/store-mediator';

--- a/packages/signalstory/src/__tests__/immutable-utility.spec.ts
+++ b/packages/signalstory/src/__tests__/immutable-utility.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable tree-shaking/no-side-effects-in-initialization */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   naiveCloneAndMutateFunc,

--- a/packages/signalstory/src/__tests__/store-mediator.spec.ts
+++ b/packages/signalstory/src/__tests__/store-mediator.spec.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable tree-shaking/no-side-effects-in-initialization */
 import { Store } from '../lib/store';
 import { createEvent, StoreEvent } from '../lib/store-event';
 import {

--- a/packages/signalstory/src/__tests__/store-plugin-deep-freeze.spec.ts
+++ b/packages/signalstory/src/__tests__/store-plugin-deep-freeze.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable tree-shaking/no-side-effects-in-initialization */
 import { computed } from '@angular/core';
 import { ImmutableStore } from '../lib/store-immutability/immutable-store';
 import { deepFreeze } from '../lib/store-plugin-deep-freeze/deep-freeze';

--- a/packages/signalstory/src/__tests__/store-plugin-history.spec.ts
+++ b/packages/signalstory/src/__tests__/store-plugin-history.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable tree-shaking/no-side-effects-in-initialization */
 import { Store } from '../lib/store';
 import { ImmutableStore } from '../lib/store-immutability/immutable-store';
 import { useDeepFreeze } from '../lib/store-plugin-deep-freeze/plugin-deep-freeze';

--- a/packages/signalstory/src/__tests__/store-plugin-performance-counter.spec.ts
+++ b/packages/signalstory/src/__tests__/store-plugin-performance-counter.spec.ts
@@ -1,5 +1,3 @@
-/* eslint-disable tree-shaking/no-side-effects-in-initialization */
-
 import { PerformanceCounter } from '../lib/store-plugin-performance-counter/performance-counter';
 
 describe('PerformanceCounter', () => {

--- a/packages/signalstory/src/__tests__/store-plugin-persistence.spec.ts
+++ b/packages/signalstory/src/__tests__/store-plugin-persistence.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable tree-shaking/no-side-effects-in-initialization */
 import { Store } from '../lib/store';
 import { AsyncStorage } from '../lib/store-plugin-persistence/persistence-async-storage';
 import { SyncStorage } from '../lib/store-plugin-persistence/persistence-sync-storage';

--- a/packages/signalstory/src/__tests__/store-plugin-status.spec.ts
+++ b/packages/signalstory/src/__tests__/store-plugin-status.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable tree-shaking/no-side-effects-in-initialization */
 import { delay, lastValueFrom, of, tap } from 'rxjs';
 import { Store } from '../lib/store';
 import { createEffect } from '../lib/store-effect';

--- a/packages/signalstory/src/__tests__/store-plugin.spec.ts
+++ b/packages/signalstory/src/__tests__/store-plugin.spec.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable tree-shaking/no-side-effects-in-initialization */
 import { Subject, filter, lastValueFrom, of, tap, throwError } from 'rxjs';
 import { Store } from '../lib/store';
 import { createEffect } from '../lib/store-effect';

--- a/packages/signalstory/src/__tests__/store-snapshot.spec.ts
+++ b/packages/signalstory/src/__tests__/store-snapshot.spec.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable tree-shaking/no-side-effects-in-initialization */
 import { Store } from '../lib/store';
 import { clearRegistry, forEachStoreInScope } from '../lib/store-registry';
 import { StateSnapshot, createSnapshot } from '../lib/store-snapshot';

--- a/packages/signalstory/src/__tests__/store.spec.ts
+++ b/packages/signalstory/src/__tests__/store.spec.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-/* eslint-disable tree-shaking/no-side-effects-in-initialization */
 import { computed, inject } from '@angular/core';
 import { Store } from '../lib/store';
 import { ImmutableStore } from '../lib/store-immutability/immutable-store';

--- a/packages/signalstory/src/lib/store-plugin-status/plugin-status.ts
+++ b/packages/signalstory/src/lib/store-plugin-status/plugin-status.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-// eslint-disable-next-line tree-shaking/no-side-effects-in-initialization
 import { Signal, WritableSignal, computed, signal } from '@angular/core';
 import { Store } from '../store';
 import { StoreEffect } from '../store-effect';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Eslint-plugin-tree-shaking does not work properly, either doesn't alert or alerts the wrong things

## What is the new behavior?

Eslint-plugin-tree-shaking has been removed, We now only rely on agadoo check in the CI pipeline

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```