### PR TITLE
feat(plugin-status): :sparkles: enhance store status plugin and improve naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,13 +182,14 @@ export const fetchBooksEffect = createEffect(
   },
   {
     setLoadingStatus: true, // indicates that the store is loading while the effect runs
-    setUnmodifiedStatus: true, // it should mark the store as unmodified upon completion
+    setInitializedStatus: true, // it should mark the store as initialized upon completion
   }
 );
 // And then run it
 myBookStore.runEffect(fetchBooksEffect).subscribe();
 const loadingSignal = isLoading(myBookStore); // true while effect is running
-const isModifiedSignal = isModified(myBookStore); // true after store update
+const initializedSignal = initialized(myBookStore); // true after initializing effect completion
+const modifiedSignal = modified(myBookStore); // true after store update
 ```
 
 ## Sample Application

--- a/docs/docs/plugins/status.md
+++ b/docs/docs/plugins/status.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Store Status
 
-Enable your store to track the loading and modification status. By utilizing the `StoreStatusPlugin`, you can monitor whether your store is currently loading (running an effect) and if it has been modified.
+Enable your store to track the loading, initialization and modification status. By utilizing the `StoreStatusPlugin`, you can monitor whether your store is currently loading (running an effect) and if it has been initialized or modified.
 
 ## Enabling Store Status
 
@@ -148,18 +148,19 @@ const effectThatLoadsBooks = createEffect(
 );
 ```
 
-## Tracking Modification Status
+## Tracking Initialization Status
 
-The `isModified` function returns a Signal indicating whether the specified store has been modified.
+The `initialized` function returns a Signal indicating whether the specified store has been initialized by an initializing effect.
 
 ```typescript
-const modifiedSignal = isModified(store);
+const initializedSignal = initialized(store);
 ```
 
-A store is initially **unmodified**. Any command (`set`, `update`, `mutate`) applied to the store will mark it as **modified**. Additionally, an effect created with the `setUnmodifiedStatus` flag can reset the store's modification status back to **unmodified**.
+A store is initially **not initialized** and any command (`set`, `update`, `mutate`) applied to the store will not change this status.
+Only an effect created with the `setInitializedStatus` flag can set the store's initialization status to **initialized**.
 
 ```typescript
-const effectThatResetsStore = createEffect(
+const effectThatInitializesStore = createEffect(
   'Load Books',
   (store: BookStore): Observable<unknown> => {
     return inject(BookService);
@@ -167,17 +168,26 @@ const effectThatResetsStore = createEffect(
   },
   // highlight-start
   {
-    setUnmodifiedStatus: true,
+    setInitializedStatus: true,
   }
   // highlight-end
 );
 ```
 
-### Manually Marking as Unmodified
+## Tracking Modification Status
 
-In exceptional cases, you can manually mark a store as unmodified using the `markAsUnmodified` function. But in most scenarios, consider using the `setUnmodifiedStatus`
-flag on the relevant effects to automatically manage the modification status.
+The `modified` function returns a Signal indicating whether the specified store has been modified.
 
 ```typescript
-markAsUnmodified(store);
+const modifiedSignal = modified(store);
+```
+
+A store is initially **unmodified**. Any command (`set`, `update`, `mutate`) applied to the store will mark it as **modified**. Additionally, an effect created with the `setInitializedStatus` flag can reset the store's modification status back to **unmodified**.
+
+## Reset store status
+
+In some cases, it could be necessary to manually reset the store status to `unmodified` and `deinitialized` using the `resetStoreStatus` function.
+
+```typescript
+resetStoreStatus(store);
 ```

--- a/packages/signalstory/README.md
+++ b/packages/signalstory/README.md
@@ -140,13 +140,14 @@ export const fetchBooksEffect = createEffect(
   },
   {
     setLoadingStatus: true, // indicates that the store is loading while the effect runs
-    setUnmodifiedStatus: true, // it should mark the store as unmodified upon completion
+    setInitializedStatus: true, // it should mark the store as initialized upon completion
   }
 );
 // And then run it
 myBookStore.runEffect(fetchBooksEffect).subscribe();
 const loadingSignal = isLoading(myBookStore); // true while effect is running
-const isModifiedSignal = isModified(myBookStore); // true after store update
+const initializedSignal = initialized(myBookStore); // true after initializing effect completion
+const modifiedSignal = modified(myBookStore); // true after store update
 ```
 
 ## Sample Application

--- a/packages/signalstory/src/lib/store-effect.ts
+++ b/packages/signalstory/src/lib/store-effect.ts
@@ -18,11 +18,16 @@ export interface StoreEffectConfig {
   setLoadingStatus?: boolean;
 
   /**
-   * Indicates whether the effect sets unmodified status.
+   * @deprecated Use `setInitializedStatus` instead. This method is deprecated and will be removed in the next major release (v18).
+   */
+  setUnmodifiedStatus?: boolean;
+
+  /**
+   * Indicates whether the effect sets initialized status.
    * Only applicable if the `StoreStatus` plugin is used.
    * Defaults to false.
    */
-  setUnmodifiedStatus?: boolean;
+  setInitializedStatus?: boolean;
 }
 
 /**
@@ -92,8 +97,13 @@ export function createEffect<
       withInjectionContext:
         !arg || arg === true || (arg.withInjectionContext ?? true),
       setLoadingStatus: (arg as StoreEffectConfig)?.setLoadingStatus ?? false,
+      //TODO: remove the following line for next major update
       setUnmodifiedStatus:
         (arg as StoreEffectConfig)?.setUnmodifiedStatus ?? false,
+      setInitializedStatus:
+        (arg as StoreEffectConfig)?.setInitializedStatus ??
+        (arg as StoreEffectConfig)?.setUnmodifiedStatus ??
+        false,
     },
   };
 }

--- a/packages/signalstory/src/public-api.ts
+++ b/packages/signalstory/src/public-api.ts
@@ -31,12 +31,15 @@ export {
   useStorePersistence,
 } from './lib/store-plugin-persistence/plugin-persistence';
 export {
+  initialized,
   isAnyEffectRunning,
   isEffectRunning,
   isLoading,
   isModified,
   markAsHavingNoRunningEffects,
   markAsUnmodified,
+  modified,
+  resetStoreStatus,
   useStoreStatus,
 } from './lib/store-plugin-status/plugin-status';
 export { StoreQuery, createQuery } from './lib/store-query';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The current behavior of the Store Status Plugin involves tracking the `loading` and `modification` status of a store. 

We've recognized a need for a clearer distinction between modification and initialization. In numerous scenarios, it's essential to determine if a store has been initialized, especially after a backend call or side effect. The existing `isModified` function is not ideal for this purpose.

Additionally, the naming of `isModified`, has been identified as potentially misleading. While `isModified` is intended to indicate whether the store has been modified, it may be interpreted as an ongoing process. 

## What is the new behavior?

The `initialized` function determines if a store has been initialized, making it particularly useful after backend calls or side effects. 

`isModified` has been renamed to `modified`. These aligns well with the new `initialized` signal and aims to enhance code readability in conditionals.

Additionally, the deprecated `markAsUnmodified` function is replaced with the more comprehensive `resetStoreStatus`, allowing for manual resetting of both initialization and modification statuses.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

- Rename `setUnmodifiedStatus` to `setInitializedStatus` in effects.
- Introduce `initialized()` function to track store initialization status.
- Introduce `resetStoreStatus()` to manually reset store status.

**Deprecation:**
- Deprecate `isModified()`, use `modified()` instead.
- Deprecate `markAsUnmodified()`, use `resetStoreStatus()` instead.