### PR TITLE
feat(plugin-persistence): :sparkles: include projection in configureIndexedDb

### DIFF
--- a/docs/docs/plugins/persistence.md
+++ b/docs/docs/plugins/persistence.md
@@ -133,6 +133,14 @@ useStorePersistence(
         // Your error handler is called in the case of an initialization error
       },
     },
+    projection: {
+      onWrite: state => {
+        // Optional projection on write for obfuscation or to slim down the stored state
+      },
+      onLoad: projection => {
+        // If onWrite was specified, you have to tell the store how to consume the stored state
+      },
+    },
   })
 );
 ```

--- a/packages/signalstory/src/lib/store-plugin-persistence/idb/idb-adapter.ts
+++ b/packages/signalstory/src/lib/store-plugin-persistence/idb/idb-adapter.ts
@@ -1,6 +1,9 @@
 import { filter, first } from 'rxjs';
 import { AsyncStorage } from '../persistence-async-storage';
-import { StorePersistencePluginOptions } from '../plugin-persistence';
+import {
+  PersistenceProjection,
+  StorePersistencePluginOptions,
+} from '../plugin-persistence';
 import { getOrOpenDb, isIDBDatabase } from './idb-pool';
 
 /**
@@ -26,7 +29,7 @@ export interface IndexedDbSetupHandlers {
 /**
  * Represents the options for connecting to an IndexedDB.
  */
-export interface IndexedDbOptions {
+export interface IndexedDbOptions<TState = never, TProjection = never> {
   /**
    * The name of the IndexedDB database.
    */
@@ -54,6 +57,13 @@ export interface IndexedDbOptions {
    * Configuration options for IndexedDB setup handlers.
    */
   handlers?: IndexedDbSetupHandlers;
+
+  /**
+   * Projection functions which are applied before storing and after loading from storage
+   * This can be useful for obfuscating sensitive data prior to storing or for saving space.
+   * Optional, default nothing.
+   */
+  projection?: PersistenceProjection<TState, TProjection>;
 }
 
 /**
@@ -61,9 +71,9 @@ export interface IndexedDbOptions {
  * @param options - The configuration options for IndexedDB.
  * @returns Store persistence plugin options.
  */
-export function configureIndexedDb(
-  options: IndexedDbOptions
-): StorePersistencePluginOptions {
+export function configureIndexedDb<TState = never, TProjection = never>(
+  options: IndexedDbOptions<TState, TProjection>
+): StorePersistencePluginOptions<TState, TProjection> {
   return {
     persistenceStorage: new IndexedDbAdapter(
       options.dbName,
@@ -72,6 +82,7 @@ export function configureIndexedDb(
       options.key,
       options.handlers
     ),
+    projection: options.projection,
   };
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`configureIndexedDb` does not include a parameter for projection functions. Hence we would have to combine them using spreading.

## What is the new behavior?

Instead of combining the result of configureIndexedDb with the optional projection function using
spreading, we can now use configureIndexedDb by itself to configure the plugin completely

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```