### PR TITLE
feat(plugin-history): :sparkles: introduce pruning for limiting memory usage

### DIFF
--- a/docs/docs/plugins/history.md
+++ b/docs/docs/plugins/history.md
@@ -26,9 +26,31 @@ class StoreWithHistory extends Store<MyState> {
 
 By enabling state history, signalstory will automatically store the history of state changes within the store by tracking `set`, `update` and `mutate` calls.
 
+## Configuration
+
+The `useStoreHistory` function accepts an optional configuration object, providing customization options for the history plugin. The available options are:
+
+| Option      | Description                    | Default Value |
+| ----------- | ------------------------------ | ------------- |
+| `maxLength` | Maximum length of the history. | `undefined`   |
+
+Example:
+
+```typescript
+useStoreHistory({
+  maxLength: 100,
+});
+```
+
+:::caution
+
+By defining `maxLength`, you can control the history size, keeping memory usage in check. If left unspecified (`undefined`), the history will expand without constraints. The choice not to set a default max length aims to maintain compatibility with versions `17.*`, as this would introduce a Breaking Change. A designated default value will be introduced starting from version `18`.
+
+:::
+
 ## Accessing State History
 
-Once the state history is enabled, you can access the history of a store using the `getHistory` method provided by signalstory.
+Once the state history is enabled, you can access the history of a store using the `getHistory` method.
 
 ```typescript
 getHistory(store);

--- a/packages/signalstory/src/lib/store-plugin-history/history.ts
+++ b/packages/signalstory/src/lib/store-plugin-history/history.ts
@@ -155,3 +155,34 @@ export function redo<TState>(
 
   return null;
 }
+
+/**
+ * Prunes the history by removing a fraction from the beginning of its elements.
+ *
+ * @param history - The history to be pruned.
+ * @param fraction - The fraction of elements to be removed. Should be a value between 0 and 1.
+ *
+ * @remarks
+ * This function modifies the input `history` array in place by removing the specified fraction of elements.
+ * The `fraction` parameter represents the portion of elements to be removed from the beginning of the history.
+ * Additionally, it adjusts special properties such as `redoneCommandIndex` and `undoneCommandIndex` in the history items.
+ *
+ */
+export function prune<TState>(
+  history: History<TState>,
+  fraction: number
+): void {
+  const deleteCount = Math.floor(history.length * fraction);
+
+  if (deleteCount > 0) {
+    history.splice(0, deleteCount);
+
+    history.forEach(command => {
+      if (isHistoryRedoItem(command)) {
+        command.redoneCommandIndex -= deleteCount;
+      } else if (isHistoryUndoItem(command)) {
+        command.undoneCommandIndex -= deleteCount;
+      }
+    });
+  }
+}

--- a/packages/signalstory/src/lib/store-plugin-history/plugin-history.ts
+++ b/packages/signalstory/src/lib/store-plugin-history/plugin-history.ts
@@ -58,16 +58,6 @@ export function registerStateHistory<TStore extends Store<any>>(
 }
 
 /**
- * Clears the history for a store.
- * @param store The store to clear history for.
- */
-export function clearStateHistory<TStore extends Store<any>>(
-  store: TStore
-): void {
-  storeHistoryRegistry.delete(store);
-}
-
-/**
  * Gets the history of commands for a store as readonly.
  * @param store The store to get history for.
  * @returns An array of history items as readonly


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Any store history grows indefinitely. This behavior might lead to increased memory usage and potential performance issues, especially in scenarios with a high volume of state changes.

## What is the new behavior?

The new behavior introduces a configurable `maxLength` option for the history plugin. Users can now set a maximum length for the history, providing better control over memory consumption. If left unspecified (`undefined`), the history will still grow without boundaries, maintaining backward compatibility with version `17.*`. Starting from version `18`, a defined default value for maxLength will be in place. This change enhances the plugin's flexibility and addresses potential concerns related to memory management.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```