### PR TITLE
feat(store): ✨ add a computed function to the store that abstracts the state's signal value into a more user friendly way

### DIFF
--- a/docs/docs/building-blocks/query.md
+++ b/docs/docs/building-blocks/query.md
@@ -10,7 +10,7 @@ Since `signalstory` uses [signals](https://angular.io/guide/signals#computed-sig
 
 ## Store Queries
 
-You can use the `state()` getter to access the entire state of the store. To select a slice or to apply transformations use angulars `computed` function. To define a query, you can create a function within your store that encapsulates the logic for accessing the desired data from the state.
+You can use the `state()` getter to access the entire state of the store. To select a slice or to apply transformations use angular's `computed` function or the `computed` function provided by the store. To define a query, you can create a function within your store that encapsulates the logic for accessing the desired data from the state.
 
 ```typescript
 import { computed } from '@angular/core';
@@ -40,6 +40,8 @@ const counterStore = new CounterStore();
 console.log(counterStore.state()); // prints 0
 console.log(counterStore.plus100()); // prints 100
 console.log(counterStore.plusN(200)()); // prints 300
+console.log(counterStore.computed(state => state + 500)); // returns a Signal<number>
+console.log(counterStore.computed(state => state + 500)()); // prints 500
 ```
 
 The created signals `plus100` and `plusN` depend on the state signal and are notified and whenever it changes.

--- a/packages/signalstory/src/__tests__/store.spec.ts
+++ b/packages/signalstory/src/__tests__/store.spec.ts
@@ -340,3 +340,35 @@ describe('runQuery', () => {
     );
   });
 });
+
+
+describe('computed', () => {
+
+  it('returns a computed signal that selects the value from the store state', () => {
+    // arrange
+    const store = new Store({ initialState: { value: 5 } });
+
+    // act
+    const computedSignal = store.computed(state => state.value);
+
+    // assert
+    expect(computedSignal()).toBe(5);
+  })
+
+  it('updates the computed signal when the state changes', () => {
+    // arrange
+    const store = new Store({ initialState: { value: 5 } });
+
+    // act
+    const computedSignal = store.computed(state => state.value);
+
+    // assert
+    expect(computedSignal()).toBe(5);
+
+    // act
+    store.set({ value: 10 });
+
+    // assert
+    expect(computedSignal()).toBe(10);
+  })
+})

--- a/packages/signalstory/src/lib/store.ts
+++ b/packages/signalstory/src/lib/store.ts
@@ -222,7 +222,22 @@ export class Store<TState> {
   }
 
   /**
-   * Runs a store query potentially targeting many differnt stores with the provided arguments and returns the result.
+   * Creates a computed signal that selects a value from the store's state. This is useful
+   * for creating derived state and binding it into the component tree.
+   *
+   * Use the `runQuery` method if you are targeting multiple stores.
+   *
+   * @param selectFunction A function to select the computed value from the store's state.
+   * @typeparam T The type of the computed signal result.
+   * @typeparam TState The type of the store's state.
+   * @returns The computed signal.
+   */
+  public computed<T>(selectFunction: (state: TState) => T): Signal<T> {
+    return computed(() => selectFunction(this._state()));
+  }
+
+  /**
+   * Runs a store query potentially targeting many different stores with the provided arguments and returns the result.
    * @typeparam TResult The type of the query's result.
    * @typeparam TStores The types of the stores used in the query.
    * @typeparam TArgs The type of the query's arguments.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines
 - Please note, I've done this for the PR commit message but not all of the commits themselves.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

@zuriscript I'm on the fence about whether this is one that should go in. On the one hand, I think it is quite nice for selecting a value from a store and binding that into a component. For instance:

```typescript
@Component({
	selector: 'app-root',
  	templateUrl: './app.component.html',
  	styleUrls: ['./app.component.scss'],
  	standalone: true,
  	imports: [],
})
export class AppComponent {

	appStore = inject(AppStore);
	darkMode = this.appStore.computed(state => state.darkMode);

}
```

The alternative would be:
```typescript
@Component({
	selector: 'app-root',
  	templateUrl: './app.component.html',
  	styleUrls: ['./app.component.scss'],
  	standalone: true,
  	imports: [],
})
export class AppComponent {

	appStore = inject(AppStore);
	darkMode = computed(() => this.appStore.state().darkMode);

}
```


I quite like the removal of the `()` on the state call.

Happy to discuss further, and I'm also happy to remove this if you don't feel it's a good addition.

